### PR TITLE
fix(ci): extend triggers to cover next branch and chore/** PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ on:
   push:
     branches:
       - master
+      - next
       - "feature/**"
       - "bug/**"
       - "fix/**"
+      - "chore/**"
     tags: ["v*"]
   pull_request:
-    branches: [master]
+    branches: [master, next]
   workflow_dispatch:
 
 # Cancel any in-progress run for the same branch/PR when a new commit arrives.


### PR DESCRIPTION
Without these changes PRs targeting `next` never receive the required `lint`/`test` status checks, making them unmergeable. Also adds `chore/**` so the monthly lockfile-update branch gets CI checks automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)