### PR TITLE
docs: point README badges at next branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![CI](https://github.com/bvacaliuc/quicknxs/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/bvacaliuc/quicknxs/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/bvacaliuc/quicknxs/branch/master/graph/badge.svg)](https://codecov.io/gh/bvacaliuc/quicknxs)
+[![CI](https://github.com/bvacaliuc/quicknxs/actions/workflows/ci.yml/badge.svg?branch=next)](https://github.com/bvacaliuc/quicknxs/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/bvacaliuc/quicknxs/branch/next/graph/badge.svg)](https://codecov.io/gh/bvacaliuc/quicknxs)
 
 # QuickNXS v1
 


### PR DESCRIPTION
next is now the default integration branch; update CI and Codecov badge URLs from master to next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)