### PR TITLE
fix(ci): remove pixi from publish job — versioningit not in runtime env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up pixi environment
-        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e  # v0.9.4
-        with:
-          cache: true
-
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,8 +106,7 @@ jobs:
           IS_RC="${{ contains(github.ref, 'rc') }}"
           PRERELEASE_FLAG=""
           if [ "${IS_RC}" = "true" ]; then PRERELEASE_FLAG="--prerelease"; fi
-          VERSION_NUMBER="$(pixi run show-version)"
-          echo "Tag: ${VERSION}  |  Computed version: ${VERSION_NUMBER}"
+          echo "Creating GitHub Release for ${VERSION}"
           gh release create "${VERSION}" \
             --title "QuickNXS ${VERSION}" \
             --generate-notes \


### PR DESCRIPTION
## Problem

The `publish` job called `pixi run show-version` (`python -m versioningit`) to log the computed version. However, `versioningit` is a **build-time dependency** only (declared in `[build-system].requires`) and is placed in pip's isolated build environment during `pixi install` — it is not importable in the pixi runtime environment. This caused the job to fail immediately:

```
No module named versioningit
```

## Fix

Drop the `setup-pixi` step from the `publish` job entirely — a full pixi install is unnecessary for creating a GitHub Release. The version is already encoded in `${GITHUB_REF_NAME}` (the tag), so the logging line is simplified to use that directly.

The `publish` job now only needs:
1. `actions/checkout` (with fetch-depth + fetch-tags for `--verify-tag`)
2. `gh release create` (pre-installed on GitHub-hosted runners)

## Test plan

- [ ] Merge this PR to `next`
- [ ] Push `next` to `qa`: `git push origin next:qa`
- [ ] Delete the failed pre-release for `v1.2.0rc1` on GitHub and re-tag: `git push origin --delete v1.2.0rc1 && git tag -d v1.2.0rc1 && git tag v1.2.0rc1 && git push origin v1.2.0rc1`
- [ ] Confirm all 3 CI jobs pass and a GitHub pre-release `v1.2.0rc1` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)